### PR TITLE
feat: migrate to PyPI Trusted Publishing (OIDC) and bump version to v4.1.0

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,7 +3,6 @@ name: Upload Python Package
 on:
   release:
     types: [published]
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 permissions:
@@ -13,7 +12,6 @@ jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
     
@@ -23,8 +21,7 @@ jobs:
         python-version: "3.x"
 
     - name: Install pypa/build
-      run: >-
-        python3 -m pip install build --user
+      run: python3 -m pip install build --user
 
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
@@ -37,15 +34,14 @@ jobs:
 
   publish-to-pypi:
     name: Publish to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # Only publish tagged releases
-    needs:
-    - build
+    if: github.event_name == 'release' && github.event.action == 'published'
+    needs: [build]
     runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/p/thumb-gen
     permissions:
-      id-token: write
+      id-token: write  # MANDATORY: for fetching the OIDC token
 
     steps:
     - name: Download all the dists
@@ -56,7 +52,3 @@ jobs:
 
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        # If you are using Trusted Publishing (OIDC); remove the password line below.
-        # If you are using the classic API Token; keep this line.
-        password: ${{ secrets.TWINE_TOKEN }}

--- a/thumb_gen/version.py
+++ b/thumb_gen/version.py
@@ -1,2 +1,2 @@
-__version__ = "4.0.2"
+__version__ = "4.1.0"
 config_version = "2021.04.03"


### PR DESCRIPTION
This PR transitions our deployment pipeline from using a static PyPI API token to **Trusted Publishing (OIDC)**. This improves security by using short-lived, environment-bound tokens instead of long-lived repository secrets.

### Key Changes

- Workflow Update: Modified `.github/workflows/python-publish.yml` to use `id-token: write` permissions.
- Security: Removed the requirement for the `TWINE_TOKEN` secret in the publish step.
- Version Bump: Updated package version to `v4.1.0` in preparation for the next release.